### PR TITLE
Backport 3.0.0-9.1 from Bionic to Xenial (incl. Python 3 support)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,50 @@
+protobuf (3.0.0-9.1ubuntu1+exo1~xenial) UNRELEASED; urgency=low
+
+  * Backport from Bionic to Xenial (incl. Python 3 support)
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Thu, 18 Jun 2020 12:52:50 +0200
+
+protobuf (3.0.0-9.1ubuntu1) bionic; urgency=low
+
+  * Merge from Debian unstable.  Remaining changes:
+    - Run jdbc-tests autopkg test allowing output on stderr (warning with
+      illegal reflective access operation on OpenJDK 9).
+    - Backport upstream fix to hide unnecessary exported symbols
+
+ -- Gianfranco Costamagna <locutusofborg@debian.org>  Fri, 30 Mar 2018 11:08:42 +0200
+
+protobuf (3.0.0-9.1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+
+  [ Mattia Rizzolo ]
+  * Apply patch from Ubuntu to fix tests with Python 3.6.  Closes: #862805
+  * Add missing Build-Depends on python-six.
+
+  [ Helmut Grohne ]
+  * Fix FTCBFS:
+    + Remove unneeded versioned Build-Depends on g++ (satisfied in oldstable).
+    + Remove unused Build-Depends on python-google-apputils.
+    + Build-Depend on python(3)-all-dev instead of python(3)-all +
+      libpython(3)-all-dev.
+    + Run generate_descriptor_proto.sh on a native build before performing
+      the actual cross build.
+    + Save the native protoc in debian/native_protoc/ and pass it to the
+      cross build via --with-protoc.
+    + Set up environment variables for cross building python extensions.
+    + Fix the loops used for the python(3) builds install and tests, to
+      actually build for all python versions and tests them all.
+    + Closes: #846343
+
+ -- Mattia Rizzolo <mattia@debian.org>  Mon, 16 Oct 2017 13:34:16 +0200
+
+protobuf (3.0.0-9ubuntu6) bionic; urgency=medium
+
+  * Run jdbc-tests autopkg test allowing output on stderr (warning with
+    illegal reflective access operation on OpenJDK 9).
+
+ -- Matthias Klose <doko@ubuntu.com>  Thu, 29 Mar 2018 15:39:23 +0800
+
 protobuf (3.0.0-9ubuntu5~xenial0+exo1) xenial; urgency=medium
 
   * Backport for Xenial.

--- a/debian/control
+++ b/debian/control
@@ -14,19 +14,18 @@ Build-Depends:
  , debhelper (>= 9)
  , dh-autoreconf
 # C/C++
- , g++ (>= 4:4.7)
  , zlib1g-dev
  , google-mock
  , libgtest-dev
 # Python
  , dh-python
- , python-all (>= 2.7)
- , libpython-all-dev (>= 2.7)
- , python3-all (>= 3.3)
- , libpython3-all-dev (>= 3.3)
+ , python-all:any
+ , libpython-all-dev
+ , python3-all:any
+ , libpython3-all-dev
  , python-setuptools
+ , python-six
  , python3-setuptools
- , python-google-apputils
  , python3-six
 # Manpage generator
  , xmlto

--- a/debian/gbp.conf
+++ b/debian/gbp.conf
@@ -1,4 +1,0 @@
-[buildpackage]
-pristine-tar = True
-[import-orig]
-pristine-tar = True

--- a/debian/patches/python36.patch
+++ b/debian/patches/python36.patch
@@ -2,9 +2,9 @@ Description: Fix two tests with Python 3.6
 Author: Michael Hudson-Doyle <michael.hudson@ubuntu.com>
 Origin: vendor
 Bug: https://github.com/google/protobuf/issues/3037
-Last-Update: 2017-05-12
----
-This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Bug-Debian: https://bugs.debian.org/862805
+Last-Update: 2017-10-16
+
 --- a/python/google/protobuf/internal/json_format_test.py
 +++ b/python/google/protobuf/internal/json_format_test.py
 @@ -753,7 +753,7 @@

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,5 +6,5 @@ misleading-indentation.patch
 s390x.patch
 sparc64.patch
 python3_long_fix.patch
-Hide-unnecessary-exported-library-symbols.patch
 python36.patch
+Hide-unnecessary-exported-library-symbols.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,7 +2,6 @@ Restore-New-Callback-into-google-protobuf-namespace.patch
 expect_death.patch
 hurd.patch
 java-test-scope.patch
-misleading-indentation.patch
 s390x.patch
 sparc64.patch
 python3_long_fix.patch

--- a/debian/rules
+++ b/debian/rules
@@ -1,8 +1,26 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
 
+include /usr/share/dpkg/architecture.mk
+ifeq ($(origin CXX),default)
+CXX := $(DEB_HOST_GNU_TYPE)-g++
+endif
+
 %:
 	dh $@ --with autoreconf,python2,python3 --parallel
+
+ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
+override_dh_auto_configure:
+	# build for the native (i.e. build) architecture, as we need
+	# the protoc compiler for the native arch.
+	dh_auto_configure -- --host=$(DEB_BUILD_GNU_TYPE)
+
+PYTHON_CROSS_VARS += PROTOC=$(CURDIR)/debian/run_protoc
+PYTHON_CROSS_VARS += PYTHONPATH=/usr/lib/python$$pv/plat-$(DEB_HOST_MULTIARCH)
+PYTHON_CROSS_VARS += _PYTHON_HOST_PLATFORM=$(DEB_HOST_ARCH_OS)-$(DEB_HOST_GNU_CPU)
+PYTHON_CROSS_VARS += CC=$(CXX)
+PYTHON_CROSS_VARS += CXX=$(CXX)
+endif
 
 override_dh_auto_build-arch:
 ## Chicken<->Egg problem: protobuf requires self-generated .pb.go files to
@@ -12,13 +30,27 @@ override_dh_auto_build-arch:
 	dh_auto_build --arch
 	bash -x ./generate_descriptor_proto.sh
 
+ifneq ($(DEB_BUILD_ARCH),$(DEB_HOST_ARCH))
+	# save the native compiler
+	cp -Rv src/.libs debian/native_protoc
+	# clean everything but regenerated .pb.{cc,go} files
+	$(MAKE) clean
+	# cross build
+	dh_auto_configure -- --with-protoc=$(CURDIR)/debian/run_protoc
+	dh_auto_build --arch
+endif
+
 	# Generate the manpage.
 	xmlto man debian/protoc.xml
 
 	# Python and Python3 build.
 	cp -rv python python3
-	cd python && python setup.py build --cpp_implementation
-	cd python3 && python3 setup.py build --cpp_implementation
+	set -e; cd python && for pv in $(shell pyversions -vr); do \
+		$(PYTHON_CROSS_VARS) python$$pv setup.py build --cpp_implementation; \
+	done
+	set -e; cd python3 && for pv in $(shell py3versions -vr); do \
+		$(PYTHON_CROSS_VARS) python$$pv setup.py build --cpp_implementation; \
+	done
 
 override_dh_auto_build-indep:
 	dh_auto_build --indep
@@ -82,16 +114,17 @@ override_dh_auto_install-arch:
 
 	# Python install.
 	set -e; \
-	cd python && for python in $(shell pyversions -r); do \
-		$$python setup.py install --cpp_implementation \
+	cd python && for pv in $(shell pyversions -vr); do \
+		$(PYTHON_CROSS_VARS) python$$pv setup.py install --cpp_implementation \
 			--install-layout=deb --no-compile \
 			--root=$(CURDIR)/debian/python-protobuf; \
 	done
 	find $(CURDIR)/debian/python-protobuf -name 'protobuf-*-nspkg.pth' -delete
 
 	# Python3 install.
-	cd python3 && for python in $(shell py3versions -r); do \
-		$$python setup.py install --cpp_implementation \
+	set -e; \
+	cd python3 && for pv in $(shell py3versions -vr); do \
+		$(PYTHON_CROSS_VARS) python$$pv setup.py install --cpp_implementation \
 			--install-layout=deb --no-compile \
 			--root=$(CURDIR)/debian/python3-protobuf; \
 	done

--- a/debian/run_protoc
+++ b/debian/run_protoc
@@ -1,0 +1,5 @@
+#!/bin/sh
+# see debian/rules for how debian/native_protoc gets populated during cross builds
+location=$(dirname "$0")
+export LD_LIBRARY_PATH="$location/native_protoc${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$location/native_protoc/protoc" "$@"

--- a/debian/tests/control
+++ b/debian/tests/control
@@ -1,2 +1,3 @@
 Tests: simple
 Depends: @, make, python, pkg-config, zlib1g-dev, build-essential, default-jdk
+Restrictions: allow-stderr


### PR DESCRIPTION
# Description

[ch15461](https://app.clubhouse.io/exoscale/story/15461)

## Testing done

```
* ubuntu@ubuntu1804.cedric.exoscale.me:~/github/exoscale/pkg-protobuf (cedric/xenial-3.0.0-py2and3)
$ pbuilder-easy git-build -d xenial -- -nc
INFO: About to build package from branch: cedric/xenial-3.0.0-py2and3
INFO: Using PBuilder base: /var/cache/pbuilder/xenial-amd64/base.tgz
[[ ... ]]
dpkg-deb: building package 'libprotobuf10' in '../libprotobuf10_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'libprotobuf-lite10' in '../libprotobuf-lite10_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'libprotobuf-dev' in '../libprotobuf-dev_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'libprotoc10' in '../libprotoc10_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'libprotoc-dev' in '../libprotoc-dev_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'protobuf-compiler' in '../protobuf-compiler_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'python-protobuf' in '../python-protobuf_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'python3-protobuf' in '../python3-protobuf_3.0.0-9.1ubuntu1+exo1~xenial_amd64.deb'.
dpkg-deb: building package 'libprotobuf-java' in '../libprotobuf-java_3.0.0-9.1ubuntu1+exo1~xenial_all.deb'.
[[ ... ]]
DONE!
```
